### PR TITLE
Add The Little Book of Bitcoin in Tigrigna to Study Materials section

### DIFF
--- a/src/app/chapters/page.tsx
+++ b/src/app/chapters/page.tsx
@@ -953,6 +953,38 @@ export default function ChaptersPage() {
                   </div>
                 </div>
               </a>
+
+              {/* The Little Book of Bitcoin in Tigrigna */}
+              <a
+                href="https://drive.google.com/file/d/1YcU6OIHZEsp4c6KOwAVDUGI2BfNtxx5T/view?usp=drive_link"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex flex-col rounded-xl border border-teal-400/30 bg-black/60 p-6 transition hover:border-teal-400/50 hover:bg-black/80 hover:shadow-[0_0_20px_rgba(20,184,166,0.2)]"
+              >
+                <div className="mb-4 flex items-center gap-3">
+                  <div className="rounded-lg bg-teal-500/20 p-3">
+                    <BookOpen className="h-6 w-6 text-teal-400" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-teal-300 transition group-hover:text-teal-200">
+                      The Little Book of Bitcoin in Tigrigna
+                    </h3>
+                    <p className="text-sm text-zinc-400">ትግርኛ ትርጉም</p>
+                  </div>
+                </div>
+                <p className="mb-4 flex-1 text-sm text-zinc-300">
+                  A simple, beginner-friendly introduction to Bitcoin translated into Tigrigna, explaining why it matters for financial freedom.
+                </p>
+                <div className="flex items-center justify-between">
+                  <span className="rounded-full bg-teal-500/20 px-3 py-1 text-xs font-medium text-teal-300">
+                    PDF (Tigrigna)
+                  </span>
+                  <div className="flex items-center gap-2 text-sm text-teal-400">
+                    <span>Download</span>
+                    <ExternalLink className="h-4 w-4" />
+                  </div>
+                </div>
+              </a>
             </div>
             </div>
           </AnimatedSection>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Tigrigna PDF version of The Little Bitcoin Book to the Study Materials grid on the chapters page.
> 
> - **Frontend (chapters page)**:
>   - **Study Materials**: Add new card/link for `The Little Book of Bitcoin in Tigrigna` (`PDF`) with Google Drive URL in `src/app/chapters/page.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e651e28323e3c191a8e6c521586b1f1d5aa0526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->